### PR TITLE
Add Ollama setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ pip install -r requirements.txt
 Copy `.env.example` to `.env` and provide your API keys. This file also allows
 you to enable optional Telegram logging of the CLI output.
 
+### Local LLM with Ollama
+
+The default configuration uses a local Ollama server with the `phi3:mini-q4_K_M`
+model. Install [Ollama](https://ollama.com/) separately and download the model:
+
+```bash
+ollama pull phi3:mini-q4_K_M
+```
+
+You can start the server manually with `ollama serve` or run the helper script
+below which downloads the model if necessary and launches the server:
+
+```bash
+bash scripts/start_phi3_ollama.sh
+```
+
+Leave this running in a separate terminal so the framework can connect to
+`http://localhost:11434/v1`.
+
 ### Required APIs
 
 You will also need the FinnHub API for financial data. All of our code is implemented with the free tier.

--- a/scripts/start_phi3_ollama.sh
+++ b/scripts/start_phi3_ollama.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+MODEL="phi3:mini-q4_K_M"
+
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "Ollama is not installed. Please install it from https://ollama.com first." >&2
+  exit 1
+fi
+
+if ! ollama list | grep -q "$MODEL"; then
+  echo "Downloading $MODEL..."
+  ollama pull "$MODEL"
+fi
+
+echo "Starting Ollama server on http://localhost:11434/v1 ..."
+exec ollama serve
+


### PR DESCRIPTION
## Summary
- document how to run the local Phi3 LLM with Ollama
- provide helper script `scripts/start_phi3_ollama.sh` to start Ollama server

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867a66fad288331a5fd7a212d16bde1