### PR TITLE
Add language configuration and wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ TELEGRAM_BOT_TOKEN=your-telegram-token # optional, enables Telegram logging
 TELEGRAM_CHAT_ID=your-chat-id          # optional, chat to send logs to
 TRADINGAGENTS_RESULTS_DIR=./results    # where results will be stored
 TELEGRAM_ENABLED=false                 # set true to send Telegram updates
+TRADINGAGENTS_LANGUAGE=en              # default response language
 ```
+
+Set `TRADINGAGENTS_LANGUAGE` to your preferred language code (e.g. `de`) to
+receive all agent responses in that language.
 
 Alternatively you can export these variables in your shell before running the
 program.

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "backend_url": "https://api.openai.com/v1",
     "llm_profile": "local_phi3",
     "fallback_to_cloud": False,
+    "language": os.getenv("TRADINGAGENTS_LANGUAGE", "en"),
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,

--- a/tradingagents/language_wrapper.py
+++ b/tradingagents/language_wrapper.py
@@ -1,0 +1,23 @@
+class LanguageWrapper:
+    """Wrap an LLM to enforce responses in a specified language."""
+
+    def __init__(self, llm, language="en"):
+        self.llm = llm
+        self.language = language
+
+    def _prepend_language(self, messages):
+        system_prompt = {"role": "system", "content": f"Respond in {self.language}."}
+        if isinstance(messages, list):
+            return [system_prompt] + messages
+        else:  # assume string or message object
+            return [system_prompt, {"role": "user", "content": messages}]
+
+    def invoke(self, messages, **kwargs):
+        return self.llm.invoke(self._prepend_language(messages), **kwargs)
+
+    def bind_tools(self, *args, **kwargs):
+        bound = self.llm.bind_tools(*args, **kwargs)
+        return LanguageWrapper(bound, self.language)
+
+    def __getattr__(self, attr):
+        return getattr(self.llm, attr)

--- a/tradingagents/llm_factory_v1_0_009.py
+++ b/tradingagents/llm_factory_v1_0_009.py
@@ -1,4 +1,5 @@
 import os
+from .language_wrapper import LanguageWrapper
 
 
 def create_llm(cfg, *, quick=False):
@@ -6,14 +7,17 @@ def create_llm(cfg, *, quick=False):
     model = cfg["quick_think_llm"] if quick else cfg["deep_think_llm"]
     if provider == "ollama":
         from langchain_community.chat_models import ChatOllama
-        return ChatOllama(model=model, base_url=cfg["backend_url"])
+        llm = ChatOllama(model=model, base_url=cfg["backend_url"])
+        return LanguageWrapper(llm, cfg.get("language", "en"))
     if provider == "gemini":
         from langchain_google_genai import ChatGoogleGenerativeAI
-        return ChatGoogleGenerativeAI(
+        llm = ChatGoogleGenerativeAI(
             model=model,
             google_api_key=os.getenv("GOOGLE_API_KEY"),
             convert_system_message_to_human=True,
         )
+        return LanguageWrapper(llm, cfg.get("language", "en"))
     # default: openai
     from langchain_openai import ChatOpenAI
-    return ChatOpenAI(model=model, base_url=cfg["backend_url"])
+    llm = ChatOpenAI(model=model, base_url=cfg["backend_url"])
+    return LanguageWrapper(llm, cfg.get("language", "en"))


### PR DESCRIPTION
## Summary
- add new `TRADINGAGENTS_LANGUAGE` environment variable
- document language setting in README
- implement `LanguageWrapper` to force language in LLM replies
- apply wrapper in `create_llm`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867d4d95f0c8331895ef2cdc17c1158