### PR TITLE
Fix ChatPromptValue handling

### DIFF
--- a/tradingagents/agents/analysts/fundamentals_analyst.py
+++ b/tradingagents/agents/analysts/fundamentals_analyst.py
@@ -48,7 +48,9 @@ def create_fundamentals_analyst(llm, toolkit):
         prompt = prompt.partial(ticker=ticker)
 
         bound_llm = llm.bind_tools(tools)
-        chain = prompt | (lambda messages, llm=bound_llm: llm.invoke(messages))
+        chain = prompt | (
+            lambda prompt_value, llm=bound_llm: llm.invoke(prompt_value.to_messages())
+        )
 
         result = chain.invoke(state["messages"])
 

--- a/tradingagents/agents/analysts/market_analyst.py
+++ b/tradingagents/agents/analysts/market_analyst.py
@@ -73,7 +73,9 @@ Volume-Based Indicators:
         prompt = prompt.partial(ticker=ticker)
 
         bound_llm = llm.bind_tools(tools)
-        chain = prompt | (lambda messages, llm=bound_llm: llm.invoke(messages))
+        chain = prompt | (
+            lambda prompt_value, llm=bound_llm: llm.invoke(prompt_value.to_messages())
+        )
 
         result = chain.invoke(state["messages"])
 

--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -45,7 +45,9 @@ def create_news_analyst(llm, toolkit):
         prompt = prompt.partial(ticker=ticker)
 
         bound_llm = llm.bind_tools(tools)
-        chain = prompt | (lambda messages, llm=bound_llm: llm.invoke(messages))
+        chain = prompt | (
+            lambda prompt_value, llm=bound_llm: llm.invoke(prompt_value.to_messages())
+        )
         result = chain.invoke(state["messages"])
 
         report = ""

--- a/tradingagents/agents/analysts/social_media_analyst.py
+++ b/tradingagents/agents/analysts/social_media_analyst.py
@@ -44,7 +44,9 @@ def create_social_media_analyst(llm, toolkit):
         prompt = prompt.partial(ticker=ticker)
 
         bound_llm = llm.bind_tools(tools)
-        chain = prompt | (lambda messages, llm=bound_llm: llm.invoke(messages))
+        chain = prompt | (
+            lambda prompt_value, llm=bound_llm: llm.invoke(prompt_value.to_messages())
+        )
 
         result = chain.invoke(state["messages"])
 


### PR DESCRIPTION
## Summary
- handle ChatPromptValue correctly in analyst nodes

## Testing
- `pip install -e .` *(fails: Could not install dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ddecd05c8331b71007c3f7ba60ae