### PR TITLE
Add concise trading signal output

### DIFF
--- a/tradingagents/agents/managers/risk_manager.py
+++ b/tradingagents/agents/managers/risk_manager.py
@@ -22,7 +22,7 @@ def create_risk_manager(llm, memory):
         for i, rec in enumerate(past_memories, 1):
             past_memory_str += rec["recommendation"] + "\n\n"
 
-        prompt = f"""As the Risk Management Judge and Debate Facilitator, your goal is to evaluate the debate between three risk analysts—Risky, Neutral, and Safe/Conservative—and determine the best course of action for the trader. Your decision must result in a clear recommendation: Buy, Sell, or Hold. Choose Hold only if strongly justified by specific arguments, not as a fallback when all sides seem valid. Strive for clarity and decisiveness.
+        prompt = f"""As the Risk Management Judge and Debate Facilitator, your goal is to evaluate the debate between three risk analysts—Risky, Neutral, and Safe/Conservative—and determine the best course of action for the trader. Your decision must result in a clear recommendation: Buy, Sell, or Hold. Choose Hold only if strongly justified by specific arguments, not as a fallback when all sides seem valid. Strive for clarity and decisiveness. Keep the response concise.
 
 Guidelines for Decision-Making:
 1. **Summarize Key Arguments**: Extract the strongest points from each analyst, focusing on relevance to the context.
@@ -31,8 +31,9 @@ Guidelines for Decision-Making:
 4. **Learn from Past Mistakes**: Use lessons from **{past_memory_str}** to address prior misjudgments and improve the decision you are making now to make sure you don't make a wrong BUY/SELL/HOLD call that loses money.
 
 Deliverables:
-- A clear and actionable recommendation: Buy, Sell, or Hold.
-- Detailed reasoning anchored in the debate and past reflections.
+- Begin your response with the single word **BUY**, **SELL**, or **HOLD** on the first line.
+- Follow with a concise summary (no more than two short paragraphs).
+- Base the reasoning on the debate and past reflections.
 
 ---
 


### PR DESCRIPTION
## Summary
- shorten risk manager prompt
- add `short_summary` helper for final decision
- send short trading signal via Telegram
- truncate final decision in reports

## Testing
- `pytest -q`
- `python -m py_compile cli/main.py tradingagents/agents/managers/risk_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6867eb075b3883319ea36f6746bcbddb