### PR TITLE
Add Ollama server logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ below which downloads the model if necessary and launches the server:
 bash scripts/start_phi3_ollama.sh
 ```
 
+The server output is written to `logs/ollama.log` and the script checks
+whether the service starts successfully.
+
 Leave this running in a separate terminal so the framework can connect to
 `http://localhost:11434/v1`.
 

--- a/scripts/start_phi3_ollama.sh
+++ b/scripts/start_phi3_ollama.sh
@@ -1,17 +1,39 @@
 #!/usr/bin/env bash
 
 MODEL="phi3:mini-q4_K_M"
+LOG_FILE="logs/ollama.log"
 
 if ! command -v ollama >/dev/null 2>&1; then
   echo "Ollama is not installed. Please install it from https://ollama.com first." >&2
   exit 1
 fi
 
+mkdir -p "$(dirname "$LOG_FILE")"
+
 if ! ollama list | grep -q "$MODEL"; then
-  echo "Downloading $MODEL..."
-  ollama pull "$MODEL"
+  echo "Downloading $MODEL..." | tee -a "$LOG_FILE"
+  if ! ollama pull "$MODEL" >>"$LOG_FILE" 2>&1; then
+    echo "Failed to download $MODEL. Check $LOG_FILE for details." >&2
+    exit 1
+  fi
 fi
 
-echo "Starting Ollama server on http://localhost:11434/v1 ..."
-exec ollama serve
+echo "Starting Ollama server on http://localhost:11434/v1 ..." | tee -a "$LOG_FILE"
+ollama serve >>"$LOG_FILE" 2>&1 &
+PID=$!
+
+# wait up to 10 seconds for the server to respond
+for i in {1..10}; do
+  if curl -sf http://localhost:11434/v1/models >/dev/null 2>&1; then
+    echo "Ollama server started (pid $PID)" | tee -a "$LOG_FILE"
+    wait $PID
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Failed to start Ollama server. Check $LOG_FILE for details." >&2
+tail -n 20 "$LOG_FILE" >&2
+kill $PID 2>/dev/null
+exit 1
 


### PR DESCRIPTION
## Summary
- log Ollama output to `logs/ollama.log` when starting the server
- monitor startup and print errors if the server fails to start
- document new log file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867fc0d00d083318bb958a45574e937